### PR TITLE
Lists are stored as custom lists called _SaverList, which do not have…

### DIFF
--- a/eldritchmush/commands/command.py
+++ b/eldritchmush/commands/command.py
@@ -2469,7 +2469,8 @@ class CmdUnfollow(Command):
                     # Try removing them from the target's followers array.
                     try:
                         target.db.followers.remove(caller)
-                        if (target.db.followers.len() == 0):
+                        tempList = list(target.db.followers)
+                        if (tempList.len() == 0):
                             target.db.isLeading = False
                         caller.msg("|540You are no longer following " + target.key + "|n")
                         target.msg("|540"+ caller.key + " is no longer following you.|n")
@@ -2505,7 +2506,8 @@ class CmdUnfollow(Command):
                 try:
                     # Attempt to remove the follower from the leader's followers array.
                     target.db.followers.remove(caller)
-                    if (target.db.followers.len() == 0):
+                    tempList = list(target.db.followers)
+                    if (tempList.len() == 0):
                         target.db.isLeading = False
                     caller.msg("|540You are no longer following " + target.key + "|n")
                     target.msg("|540"+ caller.key + " is no longer following you.|n")


### PR DESCRIPTION
… the len() function. In order to check the length of the list, I have to convert it to a temporary python list, then check.