### PR TITLE
Fix WebSocket 15s Railway idle timeout with server keepalive

### DIFF
--- a/eldritchmush/server/conf/at_server_startstop.py
+++ b/eldritchmush/server/conf/at_server_startstop.py
@@ -22,7 +22,19 @@ def at_server_start():
     This is called every time the server starts up, regardless of
     how it was shut down.
     """
-    pass
+    from twisted.internet import task, reactor
+    from evennia.server.sessionhandler import SESSIONS
+
+    def _keepalive():
+        for session in SESSIONS.values():
+            try:
+                session.data_out(keepalive=[True])
+            except Exception:
+                pass
+
+    lc = task.LoopingCall(_keepalive)
+    # Start after 5s delay, then every 10s — keeps Railway's 15s idle timeout at bay
+    reactor.callLater(5, lc.start, 10, False)
 
 
 def at_server_stop():

--- a/frontend/src/hooks/useEvennia.js
+++ b/frontend/src/hooks/useEvennia.js
@@ -328,7 +328,7 @@ export function useEvennia() {
           pingStartRef.current = Date.now()
           ws.send(JSON.stringify([['ping', [], {}]]))
         }
-      }, 30000)
+      }, 10000)
     }
 
     ws.onmessage = (event) => {


### PR DESCRIPTION
Add Twisted LoopingCall in at_server_start() that sends a keepalive OOB message to all connected sessions every 10 seconds, keeping Railway's edge proxy from dropping idle WebSocket connections. Also reduce frontend ping interval from 30s to 10s as a second layer.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4