### PR TITLE
Fix keepalive crash: use SESSIONS.all() and session.msg()

### DIFF
--- a/eldritchmush/server/conf/at_server_startstop.py
+++ b/eldritchmush/server/conf/at_server_startstop.py
@@ -26,15 +26,15 @@ def at_server_start():
     from evennia.server.sessionhandler import SESSIONS
 
     def _keepalive():
-        for session in SESSIONS.values():
+        for session in SESSIONS.all():
             try:
-                session.data_out(keepalive=[True])
+                session.msg(keepalive=True)
             except Exception:
                 pass
 
     lc = task.LoopingCall(_keepalive)
-    # Start after 5s delay, then every 10s — keeps Railway's 15s idle timeout at bay
-    reactor.callLater(5, lc.start, 10, False)
+    # Delay 10s before first ping so server is fully up, then every 10s
+    reactor.callLater(10, lc.start, 10, False)
 
 
 def at_server_stop():


### PR DESCRIPTION
SESSIONS.values() doesn't exist on Evennia's ServerSessionHandler — use SESSIONS.all() instead. Also switch data_out() to session.msg() which is the standard Evennia API for sending to clients. The bad API call was crashing Evennia on startup causing the reconnect loop.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4