### PR TITLE
Reduce keepalive to 5s interval, fire immediately on start

### DIFF
--- a/eldritchmush/server/conf/at_server_startstop.py
+++ b/eldritchmush/server/conf/at_server_startstop.py
@@ -33,8 +33,8 @@ def at_server_start():
                 pass
 
     lc = task.LoopingCall(_keepalive)
-    # Delay 10s before first ping so server is fully up, then every 10s
-    reactor.callLater(10, lc.start, 10, False)
+    # Fire immediately at start, then every 5s — Railway idle timeout is ~10s
+    reactor.callLater(3, lc.start, 5, True)
 
 
 def at_server_stop():


### PR DESCRIPTION
Railway idle timeout appears to be ~10s not 15s. Previous 10s interval was too slow — first ping fired at t=20s after startup. Now fires at t=3s and repeats every 5s to stay well under Railway's threshold.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4