### PR TITLE
Ping immediately on connect, reduce interval to 5s

### DIFF
--- a/frontend/src/hooks/useEvennia.js
+++ b/frontend/src/hooks/useEvennia.js
@@ -320,15 +320,18 @@ export function useEvennia() {
     ws.onopen = () => {
       setConnectionState('connected')
       reconnectDelayRef.current = BASE_RECONNECT_DELAY
-      addMessage('system', `Connected to ${url}. Type |wconnect <username> <password>|n to log in.`)
+      addMessage('system', `Connected to ${url}. Type connect <username> <password> to log in.`)
 
-      // Start ping interval
-      pingIntervalRef.current = setInterval(() => {
+      // Ping immediately so Railway edge proxy sees bidirectional traffic right away,
+      // then every 5s to stay under Railway's ~10s idle timeout
+      const sendPing = () => {
         if (ws.readyState === WebSocket.OPEN) {
           pingStartRef.current = Date.now()
           ws.send(JSON.stringify([['ping', [], {}]]))
         }
-      }, 10000)
+      }
+      sendPing()
+      pingIntervalRef.current = setInterval(sendPing, 5000)
     }
 
     ws.onmessage = (event) => {


### PR DESCRIPTION
Railway drops WebSocket after ~10s server→client silence. Previously the ping only fired every 10s so the first command sent by the user landed in the dead zone before any server→client data had flowed. Now we ping immediately on open (forcing Evennia to pong right away) then every 5s to keep the connection alive.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4