### PR TITLE
Use 'evennia manage shell' instead of 'python manage.py shell'

### DIFF
--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -44,7 +44,7 @@ evennia migrate --no-input
 # Auto-create superuser from env vars (errors here must NOT stop Evennia from starting)
 if [ -n "$ADMIN_USERNAME" ] && [ -n "$ADMIN_PASSWORD" ]; then
     echo "=== Creating/verifying admin account: $ADMIN_USERNAME ==="
-    python manage.py shell -c "
+    evennia manage shell -c "
 import sys
 try:
     from evennia.accounts.models import AccountDB


### PR DESCRIPTION
manage.py is not present in the game directory — Evennia handles Django management commands through its own CLI wrapper.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4