### PR TITLE
Bypass Django password validators for admin account creation

### DIFF
--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -48,9 +48,16 @@ if [ -n "$ADMIN_USERNAME" ] && [ -n "$ADMIN_PASSWORD" ]; then
 import sys
 try:
     from evennia.accounts.models import AccountDB
-    from evennia.utils import create
+    from django.contrib.auth.hashers import make_password
     if not AccountDB.objects.filter(username='${ADMIN_USERNAME}').exists():
-        acct = create.create_account('${ADMIN_USERNAME}', '${ADMIN_EMAIL:-admin@eldritchmush.com}', '${ADMIN_PASSWORD}', is_superuser=True)
+        acct = AccountDB(
+            username='${ADMIN_USERNAME}',
+            email='${ADMIN_EMAIL:-admin@eldritchmush.com}',
+            is_superuser=True,
+            is_staff=True,
+        )
+        acct.password = make_password('${ADMIN_PASSWORD}')
+        acct.save()
         print('Admin account created: ${ADMIN_USERNAME}')
     else:
         print('Admin account already exists: ${ADMIN_USERNAME}')


### PR DESCRIPTION
Use AccountDB + make_password directly instead of create_account() which runs Django's password validators that reject simple passwords.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4