### PR TITLE
Switch nginx proxy from raw WebSocket (4002) to Evennia web server (4…

### DIFF
--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -23,7 +23,7 @@ http {
             add_header Content-Type text/plain;
         }
         location / {
-            proxy_pass http://127.0.0.1:4002;
+            proxy_pass http://127.0.0.1:4001;
             proxy_http_version 1.1;
             proxy_set_header Upgrade \$http_upgrade;
             proxy_set_header Connection \$connection_upgrade;

--- a/frontend/src/hooks/useEvennia.js
+++ b/frontend/src/hooks/useEvennia.js
@@ -305,7 +305,7 @@ export function useEvennia() {
     const isSecure = window.location.protocol === 'https:'
     const protocol = isSecure ? 'wss:' : 'ws:'
     const portStr = (port === 443 || port === 80) ? '' : `:${port}`
-    const url = `${protocol}//${host}${portStr}`
+    const url = `${protocol}//${host}${portStr}/websocket`
     let ws
     try {
       ws = new WebSocket(url)


### PR DESCRIPTION
…001)

Port 4002 is Evennia's raw Autobahn WebSocket — connections close at 300ms possibly due to protocol-level incompatibility with nginx proxy. Port 4001 is Evennia's webserver-proxy which natively handles HTTP and WebSocket upgrades. Frontend now connects to /websocket path which is where port 4001 routes WebSocket connections.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4