### PR TITLE
Use at_initial_setup.py for admin account creation, simplify start.sh

### DIFF
--- a/eldritchmush/server/conf/at_initial_setup.py
+++ b/eldritchmush/server/conf/at_initial_setup.py
@@ -1,19 +1,36 @@
 """
-At_initial_setup module template
-
-Custom at_initial_setup method. This allows you to hook special
-modifications to the initial server startup process. Note that this
-will only be run once - when the server starts up for the very first
-time! It is called last in the startup process and can thus be used to
-overload things that happened before it.
-
-The module must contain a global function at_initial_setup().  This
-will be called without arguments. Note that tracebacks in this module
-will be QUIETLY ignored, so make sure to check it well to make sure it
-does what you expect it to.
-
+At_initial_setup module — runs exactly once when the server first starts
+on a fresh database. Creates the admin account from environment variables
+so Railway deployments don't need an interactive TTY.
 """
+
+import os
 
 
 def at_initial_setup():
-    pass
+    username = os.environ.get("ADMIN_USERNAME")
+    password = os.environ.get("ADMIN_PASSWORD")
+    email = os.environ.get("ADMIN_EMAIL", "admin@eldritchmush.com")
+
+    if not username or not password:
+        return
+
+    try:
+        from evennia.accounts.models import AccountDB
+        from django.contrib.auth.hashers import make_password
+
+        if not AccountDB.objects.filter(id=1).exists():
+            acct = AccountDB(
+                id=1,
+                username=username,
+                email=email,
+                is_superuser=True,
+                is_staff=True,
+            )
+            acct.password = make_password(password)
+            acct.save()
+            print(f"[at_initial_setup] Created admin account: {username}")
+        else:
+            print("[at_initial_setup] Admin account (id=1) already exists.")
+    except Exception as e:
+        print(f"[at_initial_setup] Warning: could not create admin account: {e}")

--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -47,53 +47,12 @@ else
 fi
 
 echo "=== Running database migrations ==="
-# DJANGO_SUPERUSER_* env vars allow non-interactive superuser creation during migrate
-export DJANGO_SUPERUSER_USERNAME="${ADMIN_USERNAME:-admin}"
-export DJANGO_SUPERUSER_PASSWORD="${ADMIN_PASSWORD:-changeme}"
-export DJANGO_SUPERUSER_EMAIL="${ADMIN_EMAIL:-admin@eldritchmush.com}"
-# Disable set -e here: Evennia's initial setup exits non-zero when no TTY for
-# superuser prompt, which would kill the script before our account creation runs
-set +e
-evennia migrate --no-input
-set -e
-
-# Create admin account if not already present
-if [ -n "$ADMIN_USERNAME" ] && [ -n "$ADMIN_PASSWORD" ]; then
-    echo "=== Creating/verifying admin account: $ADMIN_USERNAME ==="
-    evennia shell -c "
-import sys
-try:
-    from evennia.accounts.models import AccountDB
-    from django.contrib.auth.hashers import make_password
-    if not AccountDB.objects.filter(id=1).exists():
-        acct = AccountDB(
-            id=1,
-            username='${ADMIN_USERNAME}',
-            email='${ADMIN_EMAIL:-admin@eldritchmush.com}',
-            is_superuser=True,
-            is_staff=True,
-        )
-        acct.password = make_password('${ADMIN_PASSWORD}')
-        acct.save()
-        print('Admin account created with id=1: ${ADMIN_USERNAME}')
-    else:
-        print('Admin account (id=1) already exists')
-except Exception as e:
-    print('Warning: could not create admin account:', e, file=sys.stderr)
-" || echo "Warning: admin account creation failed, continuing anyway"
-fi
+# at_initial_setup.py creates admin account (id=1) from ADMIN_USERNAME/ADMIN_PASSWORD
+# Evennia exits non-zero when no TTY for superuser prompt — ignore that exit code
+evennia migrate --no-input || true
 
 echo "=== Starting Evennia ==="
-# Disable set -e so evennia start failure doesn't kill the container
-set +e
-evennia start
-EVENNIA_EXIT=$?
-set -e
-
-if [ $EVENNIA_EXIT -ne 0 ]; then
-    echo "ERROR: evennia start failed with exit code $EVENNIA_EXIT — check logs above"
-    echo "Keeping container alive for debugging..."
-fi
+evennia start || true
 
 echo "=== All services running ==="
 tail -f /dev/null


### PR DESCRIPTION
at_initial_setup() is Evennia's native hook for first-run setup — it runs after migrate creates the database, before the server starts. Creating the admin account here (id=1, from ADMIN_USERNAME/PASSWORD env vars) is the correct approach. Removes all the brittle shell-based account creation from start.sh. Also adds '|| true' to migrate and evennia start so a non-zero exit never crashes the container.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4