### PR TITLE
Kill lingering Evennia processes before start to fix port 4001 conflict

### DIFF
--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -73,7 +73,12 @@ else:
 " || echo "Warning: could not pre-create Account #1"
 
 echo "=== Starting Evennia ==="
+# Kill any lingering Evennia processes from previous start attempts
+# (Portal may still hold port 4001 if a previous start timed out)
+evennia stop || true
+sleep 2
 evennia start || true
 
+sleep 5
 echo "=== All services running ==="
 tail -f /dev/null


### PR DESCRIPTION
When a previous evennia start times out (AMP connection failure), the Portal process keeps running with port 4001 bound. The next start attempt fails with CannotListenError. Run 'evennia stop' first to clear any leftover processes, then start fresh.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4