### PR TITLE
Fix port 4001 conflict on Railway redeploy

### DIFF
--- a/eldritchmush/Dockerfile
+++ b/eldritchmush/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 
 # bust cache: 2026-04-06
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc nginx netcat-openbsd \
+    gcc nginx netcat-openbsd psmisc \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -77,6 +77,9 @@ echo "=== Starting Evennia ==="
 # (Portal may still hold port 4001 if a previous start timed out)
 evennia stop || true
 sleep 2
+# Force-kill any process still holding Evennia's ports after the stop
+fuser -k 4001/tcp 4002/tcp 4005/tcp 4006/tcp 2>/dev/null || true
+sleep 1
 evennia start || true
 
 sleep 5


### PR DESCRIPTION
Add psmisc to Dockerfile so fuser is available, then use fuser -k to force-kill any processes still holding Evennia's ports (4001/4002/4005/4006) after 'evennia stop' before re-running 'evennia start'. This prevents the CannotListenError that caused the Portal to fail on successive deploys.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4