### PR TITLE
Fix port 4001 conflict: route WebSocket to 4002, HTTP to 4001

### DIFF
--- a/eldritchmush/server/conf/settings.py
+++ b/eldritchmush/server/conf/settings.py
@@ -43,8 +43,10 @@ ALLOWED_HOSTS = [
     "127.0.0.1",
 ]
 
-# WebSocket port — nginx proxies from Railway's PORT to Evennia's web server
-WEBSOCKET_CLIENT_PORT = 4001
+# Evennia's WebSocket server runs on 4002 (default).
+# nginx routes /websocket → 4002 and everything else → 4001 (HTTP proxy).
+# Do NOT set WEBSOCKET_CLIENT_PORT = 4001 here — that would create a second
+# TCP listener on 4001, conflicting with the Portal's HTTP proxy (also on 4001).
 
 
 ######################################################################

--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -22,6 +22,18 @@ http {
             return 200 "OK\n";
             add_header Content-Type text/plain;
         }
+        # WebSocket connections go to Evennia's dedicated WS server (port 4002)
+        location /websocket {
+            proxy_pass http://127.0.0.1:4002;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade \$http_upgrade;
+            proxy_set_header Connection \$connection_upgrade;
+            proxy_set_header Host \$host;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+            proxy_connect_timeout 10s;
+        }
+        # Everything else (HTTP, Evennia web client, admin) → HTTP proxy (port 4001)
         location / {
             proxy_pass http://127.0.0.1:4001;
             proxy_http_version 1.1;


### PR DESCRIPTION
Root cause: WEBSOCKET_CLIENT_PORT=4001 caused the Portal to start a second TCP listener on 4001 for WebSocket, which conflicted with the Portal's built-in HTTP reverse proxy already bound to 4001 (WEBSERVER_PORTS=[(4001,4005)]). Two Twisted services cannot share a port → CannotListenError on every deploy.

Fix:
- Remove WEBSOCKET_CLIENT_PORT override (defaults back to 4002)
- Update nginx to route /websocket → 4002 (Portal WebSocket server) and everything else → 4001 (Portal HTTP proxy)

Now Portal binds 4001 (HTTP) and 4002 (WebSocket) without conflict.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4