### PR TITLE
Fix infinite hang in evennia start via timeout + readiness probe

### DIFF
--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -86,14 +86,27 @@ else:
 
 echo "=== Starting Evennia ==="
 # Kill any lingering Evennia processes from previous start attempts
-# (Portal may still hold port 4001 if a previous start timed out)
-evennia stop || true
+evennia stop 2>/dev/null || true
 sleep 2
-# Force-kill any process still holding Evennia's ports after the stop
 fuser -k 4001/tcp 4002/tcp 4005/tcp 4006/tcp 2>/dev/null || true
 sleep 1
-evennia start || true
 
-sleep 5
+# evennia start's wait_for_status_reply has no timeout — it hangs forever if
+# the Server subprocess takes too long to signal readiness (common in Docker).
+# Use timeout(1) to cap the launcher at 120s; Portal+Server subprocesses are
+# already detached and keep running after the launcher exits.
+timeout 120 evennia start 2>&1 || true
+
+# Wait up to 120s for Evennia's WebSocket port (4002) to actually accept connections
+echo "=== Waiting for Evennia to be ready ==="
+for i in $(seq 1 60); do
+    if nc -z 127.0.0.1 4002 2>/dev/null; then
+        echo "=== Evennia is up (port 4002 open) ==="
+        break
+    fi
+    echo "  waiting... ($i/60)"
+    sleep 2
+done
+
 echo "=== All services running ==="
 tail -f /dev/null


### PR DESCRIPTION
evennia_launcher's wait_for_status_reply has no timeout — it waits forever for the Server subprocess to AMP-signal readiness, which never happens in Docker when the Server takes too long to init.

Wrap evennia start in timeout(1) so the launcher exits after 120s while Portal/Server subprocesses continue running as orphans. Then poll port 4002 (WebSocket) with nc until Evennia is actually accepting connections before proceeding.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4