### PR TITLE
Fix Server subprocess import failure: bake PYTHONPATH and DJANGO_SETT…

### DIFF
--- a/eldritchmush/Dockerfile
+++ b/eldritchmush/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-# bust cache: 2026-04-06
+# bust cache: 2026-04-07
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc nginx netcat-openbsd psmisc \
     && rm -rf /var/lib/apt/lists/*
@@ -10,6 +10,12 @@ WORKDIR /app
 RUN pip install --no-cache-dir evennia
 
 COPY . .
+
+# Bake in PYTHONPATH and DJANGO_SETTINGS_MODULE so every subprocess
+# (Portal, Server) can import 'server.conf.settings' without relying
+# on sys.path propagation through nested Popen calls.
+ENV PYTHONPATH=/app
+ENV DJANGO_SETTINGS_MODULE=server.conf.settings
 
 COPY start.sh /start.sh
 RUN chmod +x /start.sh


### PR DESCRIPTION
…INGS_MODULE into image

The Server subprocess (started Portal→Popen) failed to import evennia.utils because Django couldn't find 'server.conf.settings': evennia.utils.utils imports Django at module level, Django reads DJANGO_SETTINGS_MODULE='server.conf.settings', needs 'server' importable, needs /app in sys.path.

sys.path propagation through nested Popen calls (launcher→Portal→Server) is unreliable. Fix: set PYTHONPATH=/app and DJANGO_SETTINGS_MODULE as Dockerfile ENV so every subprocess inherits them from the OS env.

https://claude.ai/code/session_01KdzLVsJwHqhQxnS8jJuHv4