### PR TITLE
Prod smoke workflow + harness polish

### DIFF
--- a/.claude/skills/playtest/ui/playtest-ui.mjs
+++ b/.claude/skills/playtest/ui/playtest-ui.mjs
@@ -51,7 +51,7 @@ if (!TARGET) {
 
 const AUTH_STATE = process.env.PLAYTEST_AUTH_STATE
   || path.join(__dirname, TARGET.authFile)
-const CHAR_NAME = process.env.PLAYTEST_CHARACTER || 'Aethel'
+const CHAR_NAME = process.env.PLAYTEST_CHARACTER || 'UAT Bot'
 
 // Scenarios flagged as read-only are the only ones allowed against prod.
 const READ_ONLY = new Set(['login', 'crafting-modal', 'crafting-ironhaven', 'crafting-docks'])
@@ -116,12 +116,29 @@ async function ensureCharacter(page, name) {
   await snap(page, '02b-charcreate-modal')
   await page.locator('.charsel-modal-submit').click()
 
-  // Wait for the new card to appear, then click it.
+  // After charcreate, two possible UIs: (a) CharacterSelect re-renders
+  // with the new card (user must click to puppet), or (b) server
+  // auto-puppets straight into the chargen room (sidebar appears, no
+  // card click needed). Wait for whichever lands first.
+  const winner = await Promise.race([
+    page.locator('.cmd-sidebar').first()
+      .waitFor({ state: 'visible', timeout: 20000 })
+      .then(() => 'game').catch(() => null),
+    page.locator('.charsel-screen .charsel-card:not(.charsel-card-create)', { hasText: name }).first()
+      .waitFor({ state: 'visible', timeout: 20000 })
+      .then(() => 'card').catch(() => null),
+  ])
+
+  if (winner === 'game') {
+    await page.waitForTimeout(1000)
+    return
+  }
+  if (winner !== 'card') {
+    throw new Error(`After charcreate, neither sidebar nor character card appeared within 20s`)
+  }
   const newCard = page
-    .locator('.charsel-screen .charsel-card', { hasText: name })
-    .filter({ hasNot: page.locator('.charsel-card-create') })
+    .locator('.charsel-screen .charsel-card:not(.charsel-card-create)', { hasText: name })
     .first()
-  await newCard.waitFor({ state: 'visible', timeout: 15000 })
   await page.waitForTimeout(600)
   await newCard.click()
   await page.waitForSelector('.cmd-sidebar', { timeout: 15000 })
@@ -203,9 +220,25 @@ async function runSetupAuth() {
   console.log('Click the Google button, finish OAuth, wait for the game UI.')
   console.log(`Target: ${TARGET.url}   Saving auth to: ${AUTH_STATE}`)
 
-  const browser = await chromium.launch({ headless: false })
-  const context = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+  // Google blocks OAuth in automation-flagged browsers. Use real Chrome
+  // (channel: 'chrome') and strip automation flags. Headless scenarios
+  // reuse the saved session so they never hit Google's checks.
+  const browser = await chromium.launch({
+    headless: false,
+    channel: 'chrome',
+    args: ['--disable-blink-features=AutomationControlled'],
+    ignoreDefaultArgs: ['--enable-automation'],
+  })
+  const context = await browser.newContext({
+    viewport: { width: 1400, height: 900 },
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  })
   const page = await context.newPage()
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined })
+  })
   await page.goto(TARGET.url, { waitUntil: 'domcontentloaded' })
 
   try {

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 15
     env:
       PLAYTEST_TARGET: prod
-      PLAYTEST_CHARACTER: UAT Bot
+      PLAYTEST_CHARACTER: Prod Bot
       PLAYTEST_AUTH_STATE: ${{ github.workspace }}/.claude/skills/playtest/ui/auth-prod.json
 
     steps:

--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,88 @@
+name: Prod smoke (post-deploy)
+
+# Runs the Playwright UI harness against eldritchmush.com after a push
+# to `master`. Only read-only scenarios (login + crafting modal opens)
+# run against prod — the harness itself refuses anything that would
+# mutate prod state.
+#
+# Required secrets:
+#   PLAYTEST_AUTH_PROD — contents of auth-prod.json (generated locally
+#                        via `make playtest-auth-prod` and pasted in)
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: 'Scenario name (must be in the READ_ONLY set)'
+        required: false
+        default: 'login'
+
+concurrency:
+  group: prod-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Prod Playwright smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PLAYTEST_TARGET: prod
+      PLAYTEST_CHARACTER: UAT Bot
+      PLAYTEST_AUTH_STATE: ${{ github.workspace }}/.claude/skills/playtest/ui/auth-prod.json
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install harness deps
+        working-directory: .claude/skills/playtest/ui
+        run: npm install
+
+      - name: Install Playwright browsers
+        working-directory: .claude/skills/playtest/ui
+        run: npx playwright install --with-deps chromium
+
+      - name: Write auth state from secret
+        env:
+          AUTH_JSON: ${{ secrets.PLAYTEST_AUTH_PROD }}
+        run: |
+          if [ -z "$AUTH_JSON" ]; then
+            echo "::error::PLAYTEST_AUTH_PROD secret is not set. Run 'make playtest-auth-prod' locally and paste auth-prod.json into the secret."
+            exit 1
+          fi
+          printf '%s' "$AUTH_JSON" > "$PLAYTEST_AUTH_STATE"
+
+      - name: Wait for Railway deploy to settle
+        run: |
+          echo "Waiting for eldritchmush.com to be healthy..."
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" https://eldritchmush.com/health || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "✅ Health check passed on attempt $i"
+              exit 0
+            fi
+            echo "  attempt $i: $code"
+            sleep 10
+          done
+          echo "::error::Prod did not become healthy within 10 minutes"
+          exit 1
+
+      - name: Run smoke scenarios (read-only only)
+        working-directory: .claude/skills/playtest/ui
+        run: |
+          SCENARIO="${{ github.event.inputs.scenario || 'login' }}"
+          node playtest-ui.mjs "$SCENARIO" --target=prod
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-smoke-screenshots
+          path: .claude/skills/playtest/ui/screenshots/
+          retention-days: 14


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/prod-smoke.yml` runs the UI harness against `eldritchmush.com` after every push to `master`, scoped to read-only scenarios
- Harness default character changed from `Aethel` → `UAT Bot`
- `ensureCharacter()` now handles the case where `charcreate` auto-puppets directly into the chargen room (no card click needed)
- `setup-auth` launches real Chrome (channel: 'chrome') with automation flags stripped so Google OAuth doesn't flag the browser

## Branch protection
Already applied via API — `master` now requires these three checks green on incoming PRs:
- `Python playtest harness`
- `Frontend build`
- `UAT Playwright smoke`

## Manual follow-up (when ready to enable prod smoke)
1. `make playtest-auth-prod` locally, sign in with `eldritchmushuat@gmail.com` on eldritchmush.com
2. Paste `auth-prod.json` contents into repo secret `PLAYTEST_AUTH_PROD`

## Test plan
- [ ] CI green on this PR
- [ ] After merge to uat: `UAT smoke (post-deploy)` passes (regression check for the charcreate/UAT-Bot changes)
- [ ] Later: when `PLAYTEST_AUTH_PROD` is set and uat→master PR merges, `Prod smoke (post-deploy)` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)