### PR TITLE
uat-smoke: use UAT Bot as test character

### DIFF
--- a/.github/workflows/uat-smoke.yml
+++ b/.github/workflows/uat-smoke.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     env:
       PLAYTEST_TARGET: uat
-      PLAYTEST_CHARACTER: Aethel
+      PLAYTEST_CHARACTER: UAT Bot
       PLAYTEST_AUTH_STATE: ${{ github.workspace }}/.claude/skills/playtest/ui/auth-uat.json
 
     steps:


### PR DESCRIPTION
## Summary
The `uat-smoke.yml` workflow had `PLAYTEST_CHARACTER: Aethel` hardcoded in env, overriding the new `UAT Bot` default in the harness. After merging #298, the smoke run tried to charcreate `Aethel` and hit a backdrop-intercept click error.

Fix: env → `UAT Bot` (which already exists on the UAT account with seeded recipes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)