### PR TITLE
Rename The Aentact → Songbird's Rest (Mystvale tavern)

### DIFF
--- a/.claude/skills/playtest/ui/playtest-ui.mjs
+++ b/.claude/skills/playtest/ui/playtest-ui.mjs
@@ -237,25 +237,44 @@ const SCENARIOS = {
   // "The Raven's Rest Tavern" / "Raven & Candle" to "Songbird's Rest"
   // on the target DB, and rewrite tavern-name phrases in every room/NPC
   // description. Idempotent. Runs `world/rename_tavern.py` via @py exec.
+  // Diagnostic: list all rooms whose key mentions "tavern", "raven",
+  // "inn", or "songbird" — so we know what the target DB actually
+  // has before running a rename migration.
+  'diag-taverns': async (page) => {
+    await typeCommand(page,
+      `@py import evennia; rs = list(evennia.search_object("", exact=False)) if False else []; ` +
+      `from evennia.objects.models import ObjectDB; ` +
+      `rooms = [o for o in ObjectDB.objects.all() if o.db_typeclass_path.endswith('rooms.Room') or 'Room' in o.db_typeclass_path]; ` +
+      `matches = [r for r in rooms if any(w in (r.db_key or '').lower() for w in ['tavern','raven','inn','songbird','aentact'])]; ` +
+      `me.msg(f"[diag] tavern-ish rooms: {[(r.id, r.db_key) for r in matches]}")`)
+    await page.waitForTimeout(1500)
+    await snap(page, '01-diag')
+  },
+
   'migrate-rename-tavern': async (page) => {
     // Base64-encoded rename migration so the payload is deploy-independent
     // (we don't need the branch merged to UAT to run it). Source lives in
     // eldritchmush/world/rename_tavern.py; regenerate the b64 with the
     // helper in that file when the migration changes.
     const MIGRATION_B64 =
-      'aW1wb3J0IGV2ZW5uaWEKUEFJUlMgPSBbKCJUaGUgUmF2ZW4ncyBSZXN0IGlzIiwgIlNvbmdiaXJ' +
-      'kJ3MgUmVzdCBpcyIpLAogICAgICAgICAoIlRoZSBSYXZlbidzIFJlc3QgVGF2ZXJuIiwgIlNvbm' +
-      'diaXJkJ3MgUmVzdCIpLAogICAgICAgICAoIlJhdmVuJ3MgUmVzdCBUYXZlcm4iLCAiU29uZ2Jpc' +
-      'mQncyBSZXN0IiksCiAgICAgICAgICgiUmF2ZW4gJiBDYW5kbGUiLCAiU29uZ2JpcmQncyBSZXN0' +
-      'IildCmRlZiBzdWIocyk6CiAgICBpZiBub3QgczogcmV0dXJuIHMKICAgIGZvciBvLCBuIGluIFB' +
-      'BSVJTOgogICAgICAgIHMgPSBzLnJlcGxhY2UobywgbikKICAgIHJldHVybiBzCnJlbmFtZWQgPS' +
-      'AwCnRvdWNoZWQgPSAwCmZvciByIGluIGV2ZW5uaWEuc2VhcmNoX29iamVjdCgiVGhlIFJhdmVuJ' +
-      '3MgUmVzdCBUYXZlcm4iKToKICAgIHIua2V5ID0gIlNvbmdiaXJkJ3MgUmVzdCIKICAgIHIuZGIu' +
-      'ZGVzYyA9IHN1YihyLmRiLmRlc2MpCiAgICByZW5hbWVkICs9IDEKZm9yIG8gaW4gZXZlbm5pYS5' +
-      'zZWFyY2hfb2JqZWN0KCIiKToKICAgIGQgPSBvLmRiLmRlc2MKICAgIGlmIGQgYW5kIHN1YihkKS' +
-      'AhPSBkOgogICAgICAgIG8uZGIuZGVzYyA9IHN1YihkKQogICAgICAgIHRvdWNoZWQgKz0gMQptZ' +
-      'S5tc2coZiJbbWlncmF0ZV0gcmVuYW1lZCB7cmVuYW1lZH0gdGF2ZXJuIHJvb20ocyk7IHBhdGNo' +
-      'ZWQge3RvdWNoZWR9IGRlc2MocykiKQo='
+      'aW1wb3J0IGV2ZW5uaWEKUEFJUlMgPSBbKCJUaGUgUmF2ZW4ncyBSZXN0IGlzIiwgIlNvbmdi' +
+      'aXJkJ3MgUmVzdCBpcyIpLAogICAgICAgICAoIlRoZSBSYXZlbidzIFJlc3QgVGF2ZXJuIiwg' +
+      'IlNvbmdiaXJkJ3MgUmVzdCIpLAogICAgICAgICAoIlJhdmVuJ3MgUmVzdCBUYXZlcm4iLCAi' +
+      'U29uZ2JpcmQncyBSZXN0IiksCiAgICAgICAgICgiUmF2ZW4gJiBDYW5kbGUiLCAiU29uZ2Jp' +
+      'cmQncyBSZXN0IiksCiAgICAgICAgICgiVGhlIEFlbnRhY3QgaXMiLCAiU29uZ2JpcmQncyBS' +
+      'ZXN0IGlzIiksCiAgICAgICAgICgiVGhlIEFlbnRhY3QiLCAiU29uZ2JpcmQncyBSZXN0Iiks' +
+      'CiAgICAgICAgICgidGhlIEFlbnRhY3QiLCAiU29uZ2JpcmQncyBSZXN0IiksCiAgICAgICAg' +
+      'ICgiQWVudGFjdCIsICJTb25nYmlyZCdzIFJlc3QiKV0KZGVmIHN1YihzKToKICAgIGlmIG5v' +
+      'dCBzOiByZXR1cm4gcwogICAgZm9yIG8sIG4gaW4gUEFJUlM6CiAgICAgICAgcyA9IHMucmVw' +
+      'bGFjZShvLCBuKQogICAgcmV0dXJuIHMKcmVuYW1lZCA9IDAKdG91Y2hlZCA9IDAKZm9yIG9s' +
+      'ZCBpbiAoIlRoZSBSYXZlbidzIFJlc3QgVGF2ZXJuIiwgIlRoZSBBZW50YWN0Iik6CiAgICBm' +
+      'b3IgciBpbiBldmVubmlhLnNlYXJjaF9vYmplY3Qob2xkKToKICAgICAgICByLmtleSA9ICJT' +
+      'b25nYmlyZCdzIFJlc3QiCiAgICAgICAgci5kYi5kZXNjID0gc3ViKHIuZGIuZGVzYykKICAg' +
+      'ICAgICByZW5hbWVkICs9IDEKZm9yIG8gaW4gZXZlbm5pYS5zZWFyY2hfb2JqZWN0KCIiKToK' +
+      'ICAgIGQgPSBvLmRiLmRlc2MKICAgIGlmIGQgYW5kIHN1YihkKSAhPSBkOgogICAgICAgIG8u' +
+      'ZGIuZGVzYyA9IHN1YihkKQogICAgICAgIHRvdWNoZWQgKz0gMQptZS5tc2coZiJbbWlncmF0' +
+      'ZV0gcmVuYW1lZCB7cmVuYW1lZH0gdGF2ZXJuIHJvb20ocyk7IHBhdGNoZWQge3RvdWNoZWR9' +
+      'IGRlc2MocykiKQo='
     await typeCommand(page,
       `@py import base64 as _b; exec(_b.b64decode("${MIGRATION_B64}").decode())`)
     await page.waitForTimeout(2000)
@@ -411,7 +430,7 @@ const SPEC_GRIZZLED_VETERAN = {
   // via the real drop path so the newly-added _fire_item_received →
   // quest_gather tick path is exercised end-to-end.
   key: 'grizzled_veteran', title: 'The Grizzled Veteran',
-  room: "The Aentact",
+  room: "Songbird's Rest",
   label: 'q08-grizzled-veteran',
   tick:
     `from commands.quests import quest_duel_win; ` +
@@ -572,7 +591,7 @@ async function main() {
       if (consoleAll.length < 500) consoleAll.push(`[ws<<] ${raw.slice(0, 240)}`)
       // Capture lines starting with [qtest] or [test] from server game feed.
       // Evennia wraps output frames in a Telnet/JSON envelope — cheap grep.
-      for (const tag of ['[qtest]', '[test]']) {
+      for (const tag of ['[qtest]', '[test]', '[migrate]', '[diag]']) {
         if (raw.includes(tag)) {
           const idx = raw.indexOf(tag)
           gameText.push(raw.slice(Math.max(0, idx - 10), idx + 400))

--- a/.claude/skills/playtest/ui/runs/2026-04-22T02-58-10-uat-migrate-rename-tavern/run.md
+++ b/.claude/skills/playtest/ui/runs/2026-04-22T02-58-10-uat-migrate-rename-tavern/run.md
@@ -1,0 +1,18 @@
+# Playtest run: migrate-rename-tavern
+
+- **Target:** uat (https://uat.eldritchmush.com)
+- **Character:** Quest Tester
+- **Start:** 2026-04-22T02:58:10.489Z
+- **Duration:** 8.9s
+- **Result:** ✅ PASS
+
+## Screenshots
+- `uat-migrate-rename-tavern-01-migration-done.png`
+- `uat-migrate-rename-tavern-01-post-load.png`
+- `uat-migrate-rename-tavern-02-verify.png`
+
+## Game feed (server [qtest]/[test] lines)
+_(none captured)_
+
+## Browser console errors
+_(none)_

--- a/.claude/skills/playtest/ui/runs/2026-04-22T02-59-23-uat-diag-taverns/run.md
+++ b/.claude/skills/playtest/ui/runs/2026-04-22T02-59-23-uat-diag-taverns/run.md
@@ -1,0 +1,20 @@
+# Playtest run: diag-taverns
+
+- **Target:** uat (https://uat.eldritchmush.com)
+- **Character:** Quest Tester
+- **Start:** 2026-04-22T02:59:23.065Z
+- **Duration:** 6.6s
+- **Result:** ✅ PASS
+
+## Screenshots
+- `uat-diag-taverns-01-diag.png`
+- `uat-diag-taverns-01-post-load.png`
+
+## Game feed (server [qtest]/[test] lines)
+```
+sg(f&quot;[diag] tavern-ish rooms: {[(r.id, r.db_key) for r in matches]}&quot;)"], {"type": "py_input"}]
+"text", ["[diag] tavern-ish rooms: [(2051, 'The Aentact'), (2084, 'Goldleaf \u2014 Innis Encampment')]"], {}]
+```
+
+## Browser console errors
+_(none)_

--- a/.claude/skills/playtest/ui/runs/2026-04-22T03-04-43-uat-migrate-rename-tavern/run.md
+++ b/.claude/skills/playtest/ui/runs/2026-04-22T03-04-43-uat-migrate-rename-tavern/run.md
@@ -1,0 +1,21 @@
+# Playtest run: migrate-rename-tavern
+
+- **Target:** uat (https://uat.eldritchmush.com)
+- **Character:** Quest Tester
+- **Start:** 2026-04-22T03:04:43.456Z
+- **Duration:** 8.6s
+- **Result:** ✅ PASS
+
+## Screenshots
+- `uat-migrate-rename-tavern-01-migration-done.png`
+- `uat-migrate-rename-tavern-01-post-load.png`
+- `uat-migrate-rename-tavern-02-verify.png`
+
+## Game feed (server [qtest]/[test] lines)
+```
+sg(f&quot;[migrate] rooms named Songbird&#x27;s Rest: {[(r.id, r.key) for r in rs]}&quot;)"], {"type": "py_input"}]
+"text", ["[migrate] rooms named Songbird's Rest: [(2051, \"Songbird's Rest\")]"], {}]
+```
+
+## Browser console errors
+_(none)_

--- a/eldritchmush/server/conf/inputfuncs.py
+++ b/eldritchmush/server/conf/inputfuncs.py
@@ -477,7 +477,7 @@ def text(session, *args, **kwargs):
                                     return "Gateway"
                                 # Mystvale and its sub-locations (Stag Hall is inside Mystvale)
                                 if any(w in name for w in [
-                                    "mystvale", "mistvale", "aentact", "tavern", "raven", "marketplace",
+                                    "mystvale", "mistvale", "aentact", "songbird", "tavern", "raven", "marketplace",
                                     "crafter", "maker", "forge", "workbench", "hollow",
                                     "stag hall", "hart hall", "manor row", "chantry",
                                     "herbalist", "town hall", "back alley",

--- a/eldritchmush/world/populate_mistvale.py
+++ b/eldritchmush/world/populate_mistvale.py
@@ -289,16 +289,16 @@ mystvale_square = get_or_create_room(
     "Laurent's Stag Hall fly alongside the colors of the Burgomaster's office. "
     "Merchants hawk their wares near the marketplace, while the smell of the "
     "forge drifts in from the Crafter's Quarter.\n\n"
-    "Exits lead to |wThe Aentact|n, the |wMarketplace|n, the |wCrafter's Quarter|n, "
+    "Exits lead to |wSongbird's Rest|n, the |wMarketplace|n, the |wCrafter's Quarter|n, "
     "the |wTown Hall|n, |wManor Row|n to the north, the |wsouth gate|n, and the "
     "|wnorth gate|n.",
     zone="Mystvale",
 )
 
 aentact = get_or_create_room(
-    "The Aentact",
+    "Songbird's Rest",
     "typeclasses.rooms.Room",
-    "The Aentact is Mystvale's tavern, council chamber, and beating heart. "
+    "Songbird's Rest is Mystvale's tavern, council chamber, and beating heart. "
     "A long hearth roars against the north wall, its smoke curling up past "
     "beams hung with antlers, tattered banners, and the Crow Favor tokens of "
     "guests past. Rough tables crowd the flagstone floor. A rumor board near "

--- a/eldritchmush/world/quest_data.py
+++ b/eldritchmush/world/quest_data.py
@@ -223,11 +223,11 @@ QUESTS = {
     },
 
     # ─────────────────────────────────────────────────────────────────────────
-    # MISTVALE — The Aentact
+    # MISTVALE — Songbird's Rest
     # Canon: Reboot Event 5 / "The Grizzled Veteran" (John Kozar)
     # Hamond the Talon — aka Roderick Wolf, bastard of House Laurent, now
-    # head of the Lex Talionis mercenary company — drinks at the Aentact,
-    # the Mistvale tavern. He'll wager 1 gold at his "Dance of Dragons"
+    # head of the Lex Talionis mercenary company — drinks at Songbird's
+    # Rest, the Mistvale tavern. He'll wager 1 gold at his "Dance of Dragons"
     # duel. Win and he drops a signed contract proving his betrayal of
     # the Laurents to House Oban — the betrayal that brought down Stag
     # Hall at the start of the year. Entire arc plays out Mistvale-side.
@@ -238,7 +238,7 @@ QUESTS = {
         "giver": "hamond the talon",
         "description": (
             "Hamond the Talon — a scarred old soldier with silver rings and "
-            "a leaf-green Northern Marches cloak — holds court at the Aentact, "
+            "a leaf-green Northern Marches cloak — holds court at Songbird's Rest, "
             "buying drinks for anyone who'll listen to his war stories. "
             "He's offering coin at his old dueling game: the |yDance of "
             "Dragons|n. One gold on the table, first to yield loses all. "

--- a/eldritchmush/world/rename_tavern.py
+++ b/eldritchmush/world/rename_tavern.py
@@ -19,18 +19,28 @@ def _sub(text, pairs):
 
 
 PAIRS = [
+    # Local-dev tavern (populate.py)
     ("The Raven's Rest is", "Songbird's Rest is"),
     ("The Raven's Rest Tavern", "Songbird's Rest"),
     ("Raven's Rest Tavern", "Songbird's Rest"),
     ("Raven & Candle", "Songbird's Rest"),
+    # Mystvale tavern (populate_mistvale.py)
+    ("The Aentact is", "Songbird's Rest is"),
+    ("The Aentact", "Songbird's Rest"),
+    ("the Aentact", "Songbird's Rest"),
+    ("Aentact", "Songbird's Rest"),
 ]
 
-# Rename the tavern room itself.
-for r in evennia.search_object("The Raven's Rest Tavern"):
-    r.key = "Songbird's Rest"
-    if r.db.desc:
-        r.db.desc = _sub(r.db.desc, PAIRS)
-    print(f"  renamed room → {r.key} (#{r.id})")
+# Rename both taverns: local-dev "The Raven's Rest Tavern" and the Mystvale
+# "The Aentact". Graveyard stays as "Raven's Rest Graveyard" because the
+# PAIRS target tavern-specific phrases ("Raven's Rest *Tavern*" etc.), not
+# the bare "Raven's Rest" substring.
+for old_key in ("The Raven's Rest Tavern", "The Aentact"):
+    for r in evennia.search_object(old_key):
+        r.key = "Songbird's Rest"
+        if r.db.desc:
+            r.db.desc = _sub(r.db.desc, PAIRS)
+        print(f"  renamed room → {r.key} (#{r.id})")
 
 # Patch descriptions on every room / NPC that mentions the old tavern
 # names. Graveyard stays as "Raven's Rest Graveyard" — PAIRS only targets


### PR DESCRIPTION
## Summary

Follow-up to #300. The Aentact (#2051 on UAT) is Mystvale's tavern; rename to **Songbird's Rest** so the two worlds share a single tavern name. Already applied to UAT's DB via `migrate-rename-tavern` — see `.claude/skills/playtest/ui/runs/2026-04-22T03-04-43-uat-migrate-rename-tavern/run.md`.

## Changes

- `populate_mistvale.py` — room key + desc + Mystvale Square exits blurb
- `quest_data.py` — grizzled_veteran description + canon comment header
- `inputfuncs.py` — add `songbird` to Mystvale-zone keyword list (kept `aentact` for backward-compat typing)
- `rename_tavern.py` — extend PAIRS to cover Aentact variants; rename both tavern rooms when present
- `playtest-ui.mjs` — regenerate base64 migration, point `SPEC_GRIZZLED_VETERAN` at the new key, add `[migrate]`/`[diag]` to the game-feed capture filter, add `diag-taverns` scenario

## Test plan

- [ ] Merge master → `uat` so deployed code stays aligned with the already-migrated DB
- [ ] Re-run `migrate-rename-tavern` on UAT (idempotent — should report 0 renames, non-zero desc patches if any descriptions changed in the new code)
- [ ] Run `make playtest-uat SCENARIO=quest-crows` — should still PASS
- [ ] Run `make playtest-uat SCENARIO=quest-all` — verify `grizzled_veteran` completes at Songbird's Rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)