### PR TITLE
Bump dompurify 3.3.3 → 3.4.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "eldritchmush-client",
       "version": "1.0.0",
       "dependencies": {
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1271,9 +1271,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
## Summary
- Mirrors Dependabot PR #295, which was auto-closed by today's history rewrite.
- Minor-version bump (semver-safe). Upstream release: [3.4.0](https://github.com/cure53/DOMPurify/releases/tag/3.4.0).

## Test plan
- [ ] `cd frontend && npm ci` succeeds
- [ ] `npm run build` passes
- [ ] Manual spot-check: any path that renders sanitized HTML (primarily chat/room-description rendering in the web client) still works.