### PR TITLE
CI: retry uptime probes before alerting

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,6 +1,11 @@
 # External uptime probe — pings prod + UAT /health every 15 minutes.
 # A failing run emails the repo owner via GitHub's workflow-failure
 # notification; the run history doubles as a free uptime log.
+#
+# Each probe retries up to 5 times (10s apart) before declaring an outage,
+# so a single transient blip — a network hiccup on the runner or a brief
+# container restart — does not fire a false-alarm failure email. Only a
+# sustained outage (~40s+) alerts.
 name: uptime
 on:
   schedule:
@@ -12,12 +17,20 @@ jobs:
     steps:
       - name: prod /health
         run: |
-          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 https://eldritchmush.com/health)
-          echo "prod: $code"
-          [ "$code" = "200" ]
+          for i in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 https://eldritchmush.com/health || echo 000)
+            echo "prod attempt $i: $code"
+            [ "$code" = "200" ] && exit 0
+            sleep 10
+          done
+          echo "prod failed 5/5 attempts"; exit 1
       - name: uat /health
         if: always()
         run: |
-          code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 https://uat.eldritchmush.com/health)
-          echo "uat: $code"
-          [ "$code" = "200" ]
+          for i in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 https://uat.eldritchmush.com/health || echo 000)
+            echo "uat attempt $i: $code"
+            [ "$code" = "200" ] && exit 0
+            sleep 10
+          done
+          echo "uat failed 5/5 attempts"; exit 1


### PR DESCRIPTION
## What
The `uptime` workflow curled prod/uat `/health` once and failed the run on any non-200, firing a failure email on a single transient blip (network hiccup on the GitHub runner, or a brief Railway container restart).

Each probe now retries up to 5 times, 10s apart, and only fails after a sustained (~40s+) outage — killing the false-alarm emails while still catching real outages.

## Context
Traced from a failing run (`30053519027`): 11 of the last 12 probes passed; the one failure never printed a prod HTTP code (the `curl` itself didn't complete), while uat returned 200 in the same run. Prod was healthy before, during, and after. No actual deploy or outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)