### PR TITLE
Build: pin evennia + django-allauth versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir evennia "django-allauth[socialaccount]>=0.58"
+# Pinned to the versions from the last known-good production build. Rebuilds
+# are deterministic — an upstream release won't silently break a deploy that
+# had no code changes. Bump these intentionally.
+RUN pip install --no-cache-dir evennia==5.0.1 "django-allauth[socialaccount]==65.18.0"
 
 # Copy the game code
 COPY eldritchmush/ .


### PR DESCRIPTION
## What
Pin `evennia==5.0.1` and `django-allauth[socialaccount]==65.18.0` in the Dockerfile — the versions from the last successful production build.

## Why
Both were installed unpinned (`pip install evennia "django-allauth[socialaccount]>=0.58"`), so every rebuild resolved to whatever was latest that day. A deploy with no code changes could break purely on an upstream release. Pinning makes rebuilds reproducible; bump deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)