### PR TITLE
Fix: paywall permstring case-bug + toothless aggressive NPCs

### DIFF
--- a/eldritchmush/typeclasses/accounts.py
+++ b/eldritchmush/typeclasses/accounts.py
@@ -110,8 +110,9 @@ class Account(DefaultAccount):
         if getattr(self, "is_staff", False):
             return False
         try:
-            perms = list(self.permissions.all())
-            if "Admin" in perms or "Developer" in perms:
+            # Evennia stores permstrings lowercased, so compare case-insensitively.
+            perms = [str(p).lower() for p in self.permissions.all()]
+            if "admin" in perms or "developer" in perms:
                 return False
         except Exception:
             pass

--- a/eldritchmush/typeclasses/npc.py
+++ b/eldritchmush/typeclasses/npc.py
@@ -104,7 +104,7 @@ class Npc(Character):
         quest givers instead hint at the tasks they can offer.
         """
         try:
-            if (self.db.is_aggressive and self.db.weapon_proto
+            if (self.db.is_aggressive
                     and not self.db.right_slot
                     and getattr(character, "has_account", False)):
                 self.make_equipment()
@@ -218,7 +218,12 @@ class Npc(Character):
         aggressive base Npc scales correctly without a bespoke subclass.
         Passive NPCs (no weapon_proto) are completely unaffected.
         """
-        proto = self.db.weapon_proto
+        # Aggressive mobs must be able to fight even if populate forgot to
+        # set a weapon_proto — fall back to a basic medium weapon so an
+        # unarmed antagonist never just stands there. Passive NPCs stay
+        # unarmed (no weapon_proto + not aggressive -> no-op).
+        proto = self.db.weapon_proto or (
+            "IRON_MEDIUM_WEAPON" if self.db.is_aggressive else None)
         if not proto or self.db.right_slot:
             return
         try:
@@ -272,7 +277,7 @@ class Npc(Character):
             monster_abilities.apply_regen(self)
         except Exception:
             pass
-        if not self.db.is_aggressive or not (self.db.right_slot or self.db.weapon_proto):
+        if not self.db.is_aggressive:
             self.execute_cmd("disengage")
             return
         if not self.db.right_slot:


### PR DESCRIPTION
Two prod-verified bugs found while auditing live state.

## 1. Paywall permstring exemption never fired (`accounts.py`)
`should_be_paywalled()` checked capitalized `"Admin"`/`"Developer"`, but Evennia stores permstrings **lowercase**. An account exempted via the `admin` permstring (e.g. `spencer2`, `perms=['admin','player']`, not a Django superuser) was therefore paywalled once its trial expired. Now compared case-insensitively.

## 2. ~18 aggressive mobs were toothless (`npc.py`)
Base `Npc.make_equipment()` no-ops without `db.weapon_proto`, and the engage/combat guards required a weapon — so aggressive mobs built without `weapon_proto` (The Butcher, Lynden the Murderer, the nethermancer/netherphage, 8× crypt "risen dead", caravan raiders, thornwood witch, iron guard scout, crow ambusher, The First/Second Lost) never telegraphed, never initiated combat, and disengaged if attacked.

Fix: aggressive base `Npc` now defaults to `IRON_MEDIUM_WEAPON` when no `weapon_proto` is set, and arm/telegraph/combat guards key off `is_aggressive`. Arms the existing live instances at engage-time (no DB migration) and prevents recurrence. Passive NPCs untouched.

Verified against prod DB (read-only) that these are the actual live states. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)