### PR TITLE
Fix: default NPC LLM model was a decommissioned Groq model

### DIFF
--- a/eldritchmush/world/ai_npc.py
+++ b/eldritchmush/world/ai_npc.py
@@ -21,7 +21,7 @@ Env vars:
                         to canned atmospheric lines.
     NPC_LLM_BASE_URL  — openai path only; default Groq.
     NPC_LLM_MODEL     — default "claude-haiku-4-5" (anthropic) or
-                        "meta-llama/llama-4-scout-17b-16e-instruct" (openai).
+                        "llama-3.3-70b-versatile" (openai/Groq).
     NPC_LLM_MAX_TOKENS— default 600
     NPC_LLM_TIMEOUT   — default 20 (seconds)
     NPC_LLM_WORKERS   — LLM worker threads (default 4). Replaces the old
@@ -50,7 +50,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 
 DEFAULT_BASE_URL = "https://api.groq.com/openai/v1"
-DEFAULT_MODEL = "meta-llama/llama-4-scout-17b-16e-instruct"
+DEFAULT_MODEL = "llama-3.3-70b-versatile"
 DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5"
 DEFAULT_MAX_TOKENS = 600          # ~450 words; long enough that even a
                                    # storytelling reply doesn't get cut off


### PR DESCRIPTION
`DEFAULT_MODEL` pointed at `meta-llama/llama-4-scout-17b-16e-instruct`, which Groq removed — every NPC dialogue call 404'd and NPCs fell back to canned "regards you silently" lines.

Prod **and** uat are already patched via the `NPC_LLM_MODEL` env override (now `llama-3.3-70b-versatile`, verified working live). This fixes the *source default* so any fresh deploy / env without the override works out of the box.

**Note:** the Llama-Guard moderation model (`ai_safety.py` default `llama-guard-4-12b`) is also decommissioned on Groq. Moderation currently fails open (does not block dialogue). Follow-up: set `NPC_LLM_MODERATE_MODEL` to a current guard model, or set `NPC_LLM_MODERATE=0`.

⚠️ Do not merge until confirmed the prod session is idle — merging redeploys/restarts prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)