### PR TITLE
Fix: top 5 findings from adversarial code review

### DIFF
--- a/eldritchmush/commands/default_cmdsets.py
+++ b/eldritchmush/commands/default_cmdsets.py
@@ -169,10 +169,11 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(command.CmdOpen())
         self.add(command.CmdSmile())
         self.add(command.SetGender())
-        self.add(command.SetTough())
-        self.add(command.SetWeakness())
+        # SetTough / SetWeakness / SetIndomitable are chargen stat setters
+        # (see ChargenCmdset). They must NOT live in the global character
+        # cmdset — that let any player self-buff Armor Value (settough 9999)
+        # or clear the Weakness debuff (setweakness 0) at any time.
         self.add(combat.CmdBattlefieldCommander())
-        self.add(command.SetIndomitable())
         self.add(combat.CmdRally())
         self.add(command.CharSheet())
         self.add(command.CharStatus())
@@ -347,6 +348,11 @@ class ChargenCmdset(CmdSet):
         self.add(command.SetStagger())
         self.add(command.SetVigil())
         self.add(command.SetGender())
+        # Room-scoped to the ChargenRoom only (moved out of the global
+        # CharacterCmdSet — these set combat stats / clear debuffs).
+        self.add(command.SetTough())
+        self.add(command.SetWeakness())
+        self.add(command.SetIndomitable())
         self.add(command.SetStabilize())
         self.add(command.SetMedicine())
         self.add(command.SetBattleFieldMedicine())

--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -120,13 +120,41 @@ if [ -n "$RAILWAY_VOLUME_MOUNT_PATH" ]; then
     # or if FORCE_DB_SEED=1 is set (to replace a stale/empty db).
     # This copies the world data (rooms, NPCs, items, etc.) from the repo
     # so the deploy starts with the full game world intact.
+    # Per-boot backup of the live database BEFORE anything can touch it
+    # (seed/migrate). Keeps the last 7 snapshots on the volume — the only
+    # safety net against a bad migration, corruption, or an accidental
+    # FORCE_DB_SEED. Not off-box, but far better than a single live copy.
+    if [ -f "$RAILWAY_VOLUME_MOUNT_PATH/evennia.db3" ]; then
+        mkdir -p "$RAILWAY_VOLUME_MOUNT_PATH/backups"
+        _bk="$RAILWAY_VOLUME_MOUNT_PATH/backups/evennia-$(date +%Y%m%d-%H%M%S).db3"
+        if command -v sqlite3 >/dev/null 2>&1; then
+            sqlite3 "$RAILWAY_VOLUME_MOUNT_PATH/evennia.db3" ".backup '$_bk'" \
+                && echo "=== DB backup: $_bk ===" \
+                || echo "=== WARNING: DB backup failed ==="
+        else
+            cp "$RAILWAY_VOLUME_MOUNT_PATH/evennia.db3" "$_bk" \
+                && echo "=== DB backup (cp): $_bk ==="
+        fi
+        # Retention: keep newest 7.
+        ls -1t "$RAILWAY_VOLUME_MOUNT_PATH"/backups/evennia-*.db3 2>/dev/null \
+            | tail -n +8 | xargs -r rm -f
+    fi
+
     SHOULD_SEED=0
     if [ ! -f "$RAILWAY_VOLUME_MOUNT_PATH/evennia.db3" ]; then
         SHOULD_SEED=1
         echo "=== No database on volume — will seed ==="
     elif [ "${FORCE_DB_SEED:-0}" = "1" ]; then
-        SHOULD_SEED=1
-        echo "=== FORCE_DB_SEED=1 — replacing existing database ==="
+        # Guard: refuse to blow away a live production DB unless a second,
+        # explicit confirmation var is also set. One stray env var must not
+        # be able to destroy all player data.
+        if [ "$RAILWAY_ENVIRONMENT_NAME" = "production" ] \
+                && [ "${FORCE_DB_SEED_CONFIRM:-0}" != "1" ]; then
+            echo "=== REFUSING FORCE_DB_SEED on production without FORCE_DB_SEED_CONFIRM=1 — keeping existing DB ==="
+        else
+            SHOULD_SEED=1
+            echo "=== FORCE_DB_SEED=1 — replacing existing database (backup taken above) ==="
+        fi
     else
         echo "=== Existing database found on volume — skipping seed ==="
     fi
@@ -141,6 +169,13 @@ if [ -n "$RAILWAY_VOLUME_MOUNT_PATH" ]; then
         fi
     fi
 else
+    # On a deployed environment a missing volume means every write is lost
+    # on the next redeploy. Fail loudly instead of silently running on
+    # ephemeral disk. Local dev (no RAILWAY_ENVIRONMENT_NAME) still warns.
+    if [ -n "$RAILWAY_ENVIRONMENT_NAME" ]; then
+        echo "=== FATAL: No volume mounted on '$RAILWAY_ENVIRONMENT_NAME' — refusing to run on ephemeral disk ==="
+        exit 1
+    fi
     echo "=== WARNING: No volume mounted — database will be lost on redeploy ==="
 fi
 
@@ -400,6 +435,7 @@ evennia start 2>&1 &
 
 # Wait for both Portal (4002 WebSocket) AND Server (4005 internal web) to be up.
 echo "=== Waiting for Evennia to be ready ==="
+evennia_up=0
 for i in $(seq 1 150); do
     portal_up=0
     server_up=0
@@ -407,11 +443,34 @@ for i in $(seq 1 150); do
     nc -z 127.0.0.1 4005 2>/dev/null && server_up=1
     if [ $portal_up -eq 1 ] && [ $server_up -eq 1 ]; then
         echo "=== Evennia is fully up! (Portal+Server ready after ${i}x2s) ==="
+        evennia_up=1
         break
     fi
     echo "  waiting... portal=$portal_up server=$server_up ($i/150)"
     sleep 2
 done
 
+# If Evennia never bound its ports, exit non-zero so Railway's ON_FAILURE
+# restart policy actually fires instead of leaving a zombie container that
+# still serves the static /health 200 over a dead game.
+if [ "$evennia_up" != "1" ]; then
+    echo "=== FATAL: Evennia did not become ready within 300s — exiting for restart ==="
+    exit 1
+fi
+
 echo "=== All services running ==="
-tail -f /dev/null
+
+# Watchdog: PID 1 must exit when any core process dies, otherwise a crashed
+# Evennia (or nginx) leaves a container Railway still thinks is healthy and
+# never restarts. Poll the ports + nginx master every 15s.
+while true; do
+    sleep 15
+    if ! nc -z 127.0.0.1 4002 2>/dev/null || ! nc -z 127.0.0.1 4005 2>/dev/null; then
+        echo "=== Evennia port down — exiting for restart ==="
+        exit 1
+    fi
+    if ! pgrep -x nginx >/dev/null 2>&1; then
+        echo "=== nginx not running — exiting for restart ==="
+        exit 1
+    fi
+done

--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -469,7 +469,7 @@ while true; do
         echo "=== Evennia port down — exiting for restart ==="
         exit 1
     fi
-    if ! pgrep -x nginx >/dev/null 2>&1; then
+    if ! pgrep nginx >/dev/null 2>&1; then
         echo "=== nginx not running — exiting for restart ==="
         exit 1
     fi

--- a/eldritchmush/typeclasses/npc.py
+++ b/eldritchmush/typeclasses/npc.py
@@ -780,7 +780,7 @@ class GreenSoldierBow(GreenMeleeSoldierOneHanded):
         # Catch exceptions to running active martial skills - weakness condition
         # Make sure npc is equipped:
 
-        if not self.db.right_slot or self.db.left_slot:
+        if not (self.db.right_slot or self.db.left_slot):
             self.execute_cmd('equip bow')
             pass
 
@@ -955,7 +955,7 @@ class BlueMeleeSoldierOneHanded(Npc):
         # Catch exceptions to running active martial skills - weakness condition
         # Make sure npc is equipped:
 
-        if not self.db.right_slot or self.db.left_slot:
+        if not (self.db.right_slot or self.db.left_slot):
             self.execute_cmd('equip hardened iron medium weapon')
             pass
 
@@ -1125,7 +1125,7 @@ class BlueMeleeSoldierTwoHanded(Npc):
         # Catch exceptions to running active martial skills - weakness condition
         # Make sure npc is equipped:
 
-        if not self.db.right_slot or self.db.left_slot:
+        if not (self.db.right_slot or self.db.left_slot):
             self.execute_cmd('equip hardened iron large weapon')
             pass
 
@@ -1298,7 +1298,7 @@ class BlueSoldierBow(Npc):
         # Catch exceptions to running active martial skills - weakness condition
         # Make sure npc is equipped:
 
-        if not self.db.right_slot or self.db.left_slot:
+        if not (self.db.right_slot or self.db.left_slot):
             self.execute_cmd('equip bow')
             pass
 
@@ -1361,7 +1361,7 @@ class GreenRevenant(Npc):
         chosen_command = random.choice(flat_ams_commands)
         # Catch exceptions to running active martial skills - weakness condition
         # Make sure npc is equipped:
-        if not self.db.right_slot or left_slot:
+        if not (self.db.right_slot or self.db.left_slot):
             self.execute_cmd('equip iron medium weapon')
             pass
 
@@ -1631,7 +1631,7 @@ class SkeletonArcher(Npc):
         # Bow uses archer skill; weapon_level bonus from bow level
         bow_level = getattr(bow.db, 'level', 0) or 0
         from commands.combat import Helper
-        self.db.weapon_level = Helper().weaponValue(bow_level)
+        self.db.weapon_level = Helper(self).weaponValue(bow_level)
 
     def remove_equipment(self):
         for item in list(self.contents):

--- a/eldritchmush/web/billing.py
+++ b/eldritchmush/web/billing.py
@@ -206,9 +206,8 @@ def billing_return(request):
     if request.user.is_authenticated and sub_id and _paypal_configured():
         acct = _account_for_user(request.user)
         if acct:
-            acct.db.paypal_subscription_id = sub_id
-            # Active fetch — confirm the subscription is ACTIVE
-            # before we tell the user "you're subscribed".
+            # Active fetch — confirm the subscription is ACTIVE *and that it
+            # belongs to this account* before we tell the user "subscribed".
             try:
                 token = _get_access_token()
                 resp = requests.get(
@@ -221,6 +220,21 @@ def billing_return(request):
                 )
                 if resp.status_code == 200:
                     sub = resp.json()
+                    # Ownership check. create_subscription stamps custom_id
+                    # with str(acct.id); a client-supplied subscription_id is
+                    # NOT proof of ownership. Without this, any logged-in user
+                    # could claim any ACTIVE subscription id and bypass the
+                    # paywall for free.
+                    if str(sub.get("custom_id") or "") != str(acct.id):
+                        print(
+                            f"[billing_return] REJECT sub={sub_id} "
+                            f"custom_id={sub.get('custom_id')!r} != "
+                            f"acct {acct.id}",
+                            flush=True,
+                        )
+                        return HttpResponseRedirect(
+                            f"{_site_base_url(request)}/?subscribed=0")
+                    acct.db.paypal_subscription_id = sub_id
                     pp_status = (sub.get("status") or "").upper()
                     if pp_status == "ACTIVE":
                         acct.db.subscription_status = "active"


### PR DESCRIPTION
Addresses the top 5 (risk×effort) findings from the adversarial code review. Each was hand-verified against source.

### 1. Paywall bypass — `billing_return` ownership check (`billing.py`)
Any logged-in user could supply any ACTIVE `subscription_id` and get `subscription_status="active"` free. Now verifies `sub.custom_id == acct.id`.

### 2. Self-serve stat cheating — chargen setters were global (`default_cmdsets.py`)
`SetTough`/`SetWeakness`/`SetIndomitable` moved from the global `CharacterCmdSet` to the room-scoped `ChargenCmdset`. Kills `settough 9999` (infinite AV) and `setweakness 0` (debuff clear) in normal play.

### 3. Three NPC combat crash bugs (`npc.py`)
`GreenRevenant` NameError (`left_slot`), `SkeletonArcher` `Helper()` TypeError, and a 4× operator-precedence re-equip loop. All hard-crashed or spammed during combat.

### 4 & 5. Data durability + crash recovery (`start.sh`)
- Per-boot `sqlite3 .backup` (keep 7) before seed/migrate — first backups the app has ever had.
- `FORCE_DB_SEED` refused on production without `FORCE_DB_SEED_CONFIRM=1`; missing volume on a deployed env now `exit 1` instead of running on ephemeral disk.
- `exit 1` on boot timeout + a watchdog replacing `tail -f /dev/null`, so a crashed Evennia/nginx actually triggers Railway's restart instead of a zombie container serving a static `/health` 200.

Verified: `bash -n start.sh` clean, `py_compile` clean on all three Python files.

Note: `/health` still returns a static 200 (making it proxy Evennia risks healthcheck flapping during boot) — the watchdog covers the crash-restart case; a real `/health` proxy is a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)