### PR TITLE
Security batch 2: webhook fail-closed, SECRET_KEY guard, CSP + csessid logging

### DIFF
--- a/eldritchmush/server/conf/settings.py
+++ b/eldritchmush/server/conf/settings.py
@@ -306,10 +306,27 @@ if _env_secret_key:
 # secret_settings.py is known-compromised (committed to a public repo
 # before 2026-04-22). Refuse to boot if it ever resurfaces.
 _LEAKED_SECRET_KEY = 'G~RcW6"H?pmqB=#9<,_lZ+5Ji%gsAh1LbF8z(!yN'
-if globals().get("SECRET_KEY") == _LEAKED_SECRET_KEY:
+_active_secret_key = str(globals().get("SECRET_KEY") or "")
+if _active_secret_key == _LEAKED_SECRET_KEY:
     raise RuntimeError(
         "SECRET_KEY matches the value that was committed to the public "
         "EldritchMUSH repo prior to 2026-04-22. Rotate via the "
         "DJANGO_SECRET_KEY env var (Railway > Variables) or set a fresh "
         "value in a local-only secret_settings.py. Refusing to boot."
+    )
+# Also refuse framework-default placeholder keys (Evennia ships a
+# published "changeme..." default) — these enable session-cookie forgery.
+if "changeme" in _active_secret_key.lower():
+    raise RuntimeError(
+        "SECRET_KEY is a framework default placeholder. Set a real "
+        "DJANGO_SECRET_KEY env var. Refusing to boot."
+    )
+# On any deployed environment (Railway sets RAILWAY_ENVIRONMENT_NAME,
+# surfaced as DEPLOY_ENV), secret_settings.py is absent so DJANGO_SECRET_KEY
+# is the only safe source. If it's unset we'd silently fall back to a
+# default/inherited key — refuse rather than boot insecurely.
+if DEPLOY_ENV != "local" and not _env_secret_key:
+    raise RuntimeError(
+        f"DJANGO_SECRET_KEY is not set on deployed environment "
+        f"'{DEPLOY_ENV}'. Refusing to boot with a fallback SECRET_KEY."
     )

--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -60,6 +60,10 @@ http {
         }
         # WebSocket connections go to Evennia's dedicated WS server (port 4002)
         location /websocket {
+            # The WS URL carries the Django session id (csessid) in its
+            # query string; logging it would persist a replayable session
+            # token to the log stream. Do not log this location.
+            access_log off;
             proxy_pass http://127.0.0.1:4002;
             proxy_http_version 1.1;
             proxy_set_header Upgrade \$http_upgrade;
@@ -103,6 +107,17 @@ http {
         location / {
             root /usr/share/nginx/html;
             index index.html;
+            # Security headers. script-src 'self' is the real backstop:
+            # LLM/NPC text reaches the DOM via DOMPurify, and this stops a
+            # DOMPurify bypass from executing injected <script>. Google Fonts
+            # is the only external origin the SPA loads; PayPal is a
+            # top-level redirect (no embedded SDK), so no frame/connect grant
+            # is needed for it. wss:/ws: keep the game WebSocket working.
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' wss: ws:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" always;
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
             try_files \$uri \$uri/ /index.html;
         }
     }

--- a/eldritchmush/web/billing.py
+++ b/eldritchmush/web/billing.py
@@ -287,11 +287,21 @@ def webhook(request):
     except Exception:
         return JsonResponse({"error": "bad json"}, status=400)
 
-    # Signature verification — best-effort. PayPal supports a
-    # verify-webhook-signature endpoint. We hit it only if
-    # PAYPAL_WEBHOOK_ID is set; otherwise we log a warning and
-    # accept the event (dev mode).
+    # Signature verification. PayPal supports a verify-webhook-signature
+    # endpoint keyed on PAYPAL_WEBHOOK_ID. This is a public, state-changing
+    # endpoint, so an unverified event must NOT be trusted: if PayPal is
+    # configured at all, require the webhook id and reject when it's absent
+    # rather than silently accepting forged events.
     webhook_id = os.environ.get("PAYPAL_WEBHOOK_ID")
+    if not webhook_id:
+        if _paypal_configured():
+            print(
+                "[paypal_webhook] REJECT: PAYPAL_WEBHOOK_ID unset while "
+                "PayPal is configured — cannot verify signature.",
+                flush=True,
+            )
+            return JsonResponse({"error": "webhook not configured"}, status=503)
+        # Truly local/unconfigured dev — nothing to verify against.
     if webhook_id:
         try:
             verify_body = {
@@ -319,9 +329,10 @@ def webhook(request):
                 )
         except Exception as exc:
             print(f"[paypal_webhook] verify failed: {exc!r}", flush=True)
-            # Fail closed in live mode.
-            if (os.environ.get("PAYPAL_MODE") or "sandbox").lower() == "live":
-                return JsonResponse({"error": "verify error"}, status=400)
+            # Fail closed regardless of mode. A verification error means we
+            # cannot trust the event — sandbox is a real deployed target too,
+            # so accepting on error would allow forged subscription events.
+            return JsonResponse({"error": "verify error"}, status=400)
 
     event_type = event.get("event_type", "")
     resource = event.get("resource") or {}


### PR DESCRIPTION
Second batch from the adversarial review — the next-highest security items.

1. **PayPal webhook fails closed** (`billing.py`) — reject when `PAYPAL_WEBHOOK_ID` is unset-but-configured; fail closed on verify errors regardless of `PAYPAL_MODE` (was live-only, prod is sandbox).
2. **SECRET_KEY guard** (`settings.py`) — refuse framework-default `changeme…` keys and refuse to boot on a deployed env when `DJANGO_SECRET_KEY` is unset (verified it IS set on prod+uat, so no boot breakage).
3. **csessid no longer logged** (`start.sh`) — `access_log off` on `/websocket` (the session id rode in the URL query string).
4. **CSP + security headers** (`start.sh`) — `script-src 'self'` backstop for the DOMPurify/LLM-text path, plus X-Frame-Options/nosniff/Referrer-Policy/HSTS. CSP matched to the actual loaded origins (self + Google Fonts; wss/ws for the game socket).

Verified: `bash -n`, `py_compile` clean. Post-deploy I'll load prod in a browser to confirm the CSP doesn't block the SPA/fonts/websocket before calling it done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)