### PR TITLE
Billing correctness: re-subscribe overwrite + /pricing dead-end

### DIFF
--- a/eldritchmush/web/billing.py
+++ b/eldritchmush/web/billing.py
@@ -139,6 +139,17 @@ def create_subscription(request):
     if not acct:
         return JsonResponse({"error": "no account"}, status=500)
 
+    # Refuse to create a second subscription for an already-active account.
+    # Overwriting paypal_subscription_id with a fresh (never-approved) id
+    # would orphan the live subscription's renewal/cancel webhooks and can
+    # double-bill the player.
+    if acct.db.subscription_status == "active":
+        return JsonResponse(
+            {"error": "already_subscribed",
+             "detail": "This account already has an active subscription."},
+            status=409,
+        )
+
     base = _site_base_url(request)
     body = {
         "plan_id": os.environ["PAYPAL_PLAN_ID"],
@@ -184,9 +195,17 @@ def create_subscription(request):
             {"error": "No approval link returned by PayPal"},
             status=502,
         )
-    # Store the subscription id immediately so even if the user never
-    # completes approval we have a trail.
-    acct.db.paypal_subscription_id = data.get("id")
+    # Store the new subscription id as current, and also append it to a
+    # history list so a webhook that references any prior id (e.g. the
+    # cancellation of an abandoned attempt) still resolves to this account
+    # (see _find_account_by_subscription).
+    new_sub_id = data.get("id")
+    acct.db.paypal_subscription_id = new_sub_id
+    if new_sub_id:
+        history = list(acct.db.paypal_subscription_ids or [])
+        if new_sub_id not in history:
+            history.append(new_sub_id)
+            acct.db.paypal_subscription_ids = history
     return JsonResponse({
         "subscription_id": data.get("id"),
         "approval_url": approval_url,
@@ -388,5 +407,8 @@ def _find_account_by_subscription(sub_id):
     # large, store sub_id in an indexed model field instead.
     for acct in AccountDB.objects.all():
         if acct.db.paypal_subscription_id == sub_id:
+            return acct
+        # Also match any prior id (a re-subscribe rotates the current id).
+        if sub_id in (acct.db.paypal_subscription_ids or []):
             return acct
     return None

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import './LandingPage.css'
 
 /*
@@ -50,6 +51,23 @@ const HOUSES = [
 ]
 
 export default function LandingPage({ onPlay }) {
+  // Deep-link support for /pricing — the paywall message and PayPal's
+  // cancel_url both point here. Scroll to the pricing block on load and, if
+  // PayPal bounced the user back with ?canceled=1, show a "no charge, try
+  // again" banner so checkout isn't a contextless dead-end at the page top.
+  const [checkoutCanceled, setCheckoutCanceled] = useState(false)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const canceled = params.get('canceled') === '1'
+    if (canceled) setCheckoutCanceled(true)
+    if (canceled || window.location.pathname === '/pricing') {
+      requestAnimationFrame(() => {
+        document
+          .getElementById('pricing')
+          ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      })
+    }
+  }, [])
   return (
     <div className="landing">
       <div className="landing-grain" aria-hidden="true" />
@@ -194,8 +212,25 @@ export default function LandingPage({ onPlay }) {
       </section>
 
       {/* ── Pricing + CTA ── */}
-      <section className="landing-start" aria-label="Start playing">
+      <section className="landing-start" aria-label="Start playing" id="pricing">
         <div className="landing-pricing">
+          {checkoutCanceled && (
+            <p
+              className="landing-pricing-canceled"
+              role="status"
+              style={{
+                color: '#d4af37',
+                border: '1px solid rgba(212,175,55,0.4)',
+                borderRadius: '4px',
+                padding: '0.6rem 0.9rem',
+                marginBottom: '1rem',
+                fontSize: '0.95rem',
+              }}
+            >
+              Checkout was canceled — no charge was made. You can begin the
+              free trial whenever you're ready.
+            </p>
+          )}
           <img
             src="/landing/wax-seal.png"
             alt=""


### PR DESCRIPTION
Third review batch — billing correctness.

1. **Re-subscribe orphaned the live sub** (`billing.py`) — `create_subscription` overwrote `paypal_subscription_id` unconditionally. A paying player clicking Subscribe again replaced their active sub's id with a never-approved one, orphaning its renewal/cancel webhooks (charged but drifts to paywalled). Now: refuse (409) when already active + keep a `paypal_subscription_ids` history so webhooks referencing any prior id still resolve.
2. **/pricing dead-end** (`LandingPage.jsx`) — the paywall message + PayPal `cancel_url` point at `/pricing`, which served the landing top with no context. Now scrolls to the pricing block and shows a "checkout canceled — no charge" banner on `?canceled=1`.

Verified: `py_compile` clean, `npm run build` succeeds. Will browser-check `/pricing` on prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)