### PR TITLE
Ops: durable LLM spend cap + quest-validation alerting

### DIFF
--- a/eldritchmush/server/conf/at_server_startstop.py
+++ b/eldritchmush/server/conf/at_server_startstop.py
@@ -287,8 +287,23 @@ def at_server_start():
     # instead of player-reported bugs. Never blocks startup.
     try:
         from world.quest_validation import run_and_report
-        run_and_report(check_world=True,
-                       out=lambda m: print(m, flush=True))
+        _qv_lines = []
+
+        def _qv_out(m):
+            print(m, flush=True)
+            _qv_lines.append(m)
+
+        n_quest_errors = run_and_report(check_world=True, out=_qv_out)
+        if n_quest_errors:
+            # The whole point of the validator is to catch stranded quests
+            # before players do — a log line buried in Railway deploy noise
+            # isn't enough, so email the operator (rate-limited per kind).
+            from world import telemetry
+            telemetry.alert(
+                "quest_validation",
+                f"{n_quest_errors} quest validation error(s) at boot",
+                "\n".join(_qv_lines),
+            )
     except Exception as exc:
         print(f"[at_server_start] quest validation FAILED: {exc!r}")
 

--- a/eldritchmush/world/ai_npc.py
+++ b/eldritchmush/world/ai_npc.py
@@ -130,11 +130,46 @@ def _spend_day():
     return time.strftime("%Y-%m-%d", time.gmtime())
 
 
+def _spend_file():
+    vol = os.environ.get("RAILWAY_VOLUME_MOUNT_PATH")
+    return os.path.join(vol, "llm_spend.json") if vol else "/tmp/llm_spend.json"
+
+
+def _persist_spend():
+    """Write-through today's spend so the daily cap survives a reload /
+    redeploy (module globals reset otherwise, silently zeroing the counter
+    — on a deploy-heavy day that turns a $5 cap into $5-per-deploy). Caller
+    holds _SPEND_LOCK."""
+    try:
+        with open(_spend_file(), "w", encoding="utf-8") as fp:
+            json.dump(_SPEND, fp)
+    except Exception:
+        pass
+
+
+def _load_spend():
+    """Restore today's spend at import. A stale (previous-day) file is
+    ignored so the cap still resets at UTC midnight."""
+    try:
+        with open(_spend_file(), "r", encoding="utf-8") as fp:
+            data = json.load(fp)
+        if isinstance(data, dict) and data.get("day") == _spend_day():
+            with _SPEND_LOCK:
+                _SPEND.update(
+                    day=data["day"],
+                    usd=float(data.get("usd") or 0.0),
+                    warned=bool(data.get("warned")),
+                )
+    except Exception:
+        pass
+
+
 def _spend_ok():
     with _SPEND_LOCK:
         day = _spend_day()
         if _SPEND["day"] != day:
             _SPEND.update(day=day, usd=0.0, warned=False)
+            _persist_spend()
         return _SPEND["usd"] < _budget_usd()
 
 
@@ -148,6 +183,7 @@ def _record_spend(usd):
         if _SPEND["usd"] >= _budget_usd() and not _SPEND["warned"]:
             _SPEND["warned"] = True
             tripped = True
+        _persist_spend()
     try:
         from world import telemetry
         telemetry.incr("llm.cost_usd", usd)
@@ -162,6 +198,11 @@ def _record_spend(usd):
             )
     except Exception:
         pass
+
+
+# Restore today's accumulated spend from the volume at import so a reload
+# or redeploy doesn't reset the daily cap to $0.
+_load_spend()
 
 
 # ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fourth review batch — two small operational hardening fixes.

1. **Durable LLM spend cap** (`ai_npc.py`) — was an in-process global that reset to \$0 on every reload/redeploy, so the \$5/day cap was really "\$5 per uptime window." Now write-through to `\$VOLUME/llm_spend.json` and restore at import; stale previous-day files are ignored so it still resets at UTC midnight.
2. **Quest-validation alerting** (`at_server_startstop.py`) — the validator's ERROR count was discarded (log-only). Now `telemetry.alert()`s the operator (existing rate-limited Resend email) when boot finds stranded quests.

Verified: `py_compile` clean; persistence round-trip + stale-day reset unit-smoke passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)