### PR TITLE
DB: Postgres support via DATABASE_URL (SQLite fallback, no-op until cutover)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ WORKDIR /app
 # Pinned to the versions from the last known-good production build. Rebuilds
 # are deterministic — an upstream release won't silently break a deploy that
 # had no code changes. Bump these intentionally.
-RUN pip install --no-cache-dir evennia==5.0.1 "django-allauth[socialaccount]==65.18.0"
+RUN pip install --no-cache-dir evennia==5.0.1 "django-allauth[socialaccount]==65.18.0" \
+    psycopg2-binary==2.9.10 dj-database-url==2.3.0
 
 # Copy the game code
 COPY eldritchmush/ .

--- a/eldritchmush/server/conf/settings.py
+++ b/eldritchmush/server/conf/settings.py
@@ -163,14 +163,24 @@ def _patch_evennia_superuser():
 _patch_evennia_superuser()
 
 _volume_path = os.environ.get("RAILWAY_VOLUME_MOUNT_PATH", "")
-if _volume_path:
+_database_url = os.environ.get("DATABASE_URL", "")
+if _database_url:
+    # Managed Postgres (Railway/Neon) takes precedence over the SQLite
+    # volume file — real row-level locking for concurrent play plus the
+    # provider's automated backups / point-in-time recovery.
+    import dj_database_url
+    DATABASES = {
+        "default": dj_database_url.parse(_database_url, conn_max_age=600),
+    }
+elif _volume_path:
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",
             "NAME": os.path.join(_volume_path, "evennia.db3"),
         }
     }
-    # Also persist server logs to the volume
+if _volume_path:
+    # Persist server logs to the volume regardless of DB backend.
     LOG_DIR = os.path.join(_volume_path, "logs")
     os.makedirs(LOG_DIR, exist_ok=True)
     SERVER_LOG_FILE = os.path.join(LOG_DIR, "server.log")


### PR DESCRIPTION
Backward-compatible groundwork for moving off the single SQLite file. `settings.py` prefers `DATABASE_URL` (managed Postgres) when set, else the SQLite volume. Dockerfile adds `psycopg2-binary` + `dj-database-url`. No environment sets `DATABASE_URL` yet — prod/uat keep using SQLite until an explicit cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)