### PR TITLE
Hotfix: watchdog crash-looped prod (pgrep not installed)

### DIFF
--- a/eldritchmush/start.sh
+++ b/eldritchmush/start.sh
@@ -484,8 +484,12 @@ while true; do
         echo "=== Evennia port down — exiting for restart ==="
         exit 1
     fi
-    if ! pgrep nginx >/dev/null 2>&1; then
-        echo "=== nginx not running — exiting for restart ==="
+    # Check nginx by its listening port, NOT pgrep: procps/pgrep is not
+    # installed in the image, so `pgrep nginx` errored every cycle and
+    # crash-looped a perfectly healthy container. nc IS installed
+    # (netcat-openbsd) and testing the port also catches a wedged master.
+    if ! nc -z 127.0.0.1 "${PORT:-8080}" 2>/dev/null; then
+        echo "=== nginx port down — exiting for restart ==="
         exit 1
     fi
 done


### PR DESCRIPTION
Prod went 502: the start.sh watchdog used `pgrep nginx`, but procps isn't in the image, so it errored every cycle and `exit 1`'d a healthy container until Railway's 10 retries were exhausted. Replaced with an `nc -z 127.0.0.1 $PORT` check (netcat is installed). 🤖 Generated with [Claude Code](https://claude.com/claude-code)